### PR TITLE
Fixes PHP Notice: Undefined variable: wlreq

### DIFF
--- a/includes/ss-admin-options.php
+++ b/includes/ss-admin-options.php
@@ -59,7 +59,7 @@ echo "<p>Stop Spammers has prevented $spmcount spammers from registering or leav
 echo"</p>";
 } 
 if (count($wlrequests)==1) {
-echo "<p>".count($wlreq)." user</a> has been denied access and requested that you add them to the Allow List.</p>";
+echo "<p>".count($wlrequests)." user</a> has been denied access and requested that you add them to the Allow List.</p>";
 } else if (count($wlrequests)>0) {
 echo "<p>".count($wlrequests)." users</a> have been denied access and requested that you add them to the Allow List.</p>";
 }


### PR DESCRIPTION
There are PHP notices because $wlreq doesn't exists:

`PHP Notice:  Undefined variable: wlreq in /home/.../stop-spammer-registrations-plugin/includes/ss-admin-options.php on line 81
`
It's typo - https://github.com/stodorovic/stop-spammers/blob/master/includes/ss-admin-options.php#L62