### PR TITLE
Add SFS reporting from the log page and fix IP blacklisting. (partial fix for #54)

### DIFF
--- a/includes/ss-admin-options.php
+++ b/includes/ss-admin-options.php
@@ -193,10 +193,20 @@ function sfs_handle_ajax_sub( $data ) {
 	}
 // get the comment
 	$comment = get_comment( $comment_id, ARRAY_A );
-	if ( empty( $comment ) ) {
-		echo " No Comment Found for $comment_id";
-		exit();
-	}
+  if ( $comment_id == 'registration' ) {
+    $comment = array(
+      'comment_author_email' => $_GET['email'],
+      'comment_author' => $_GET['user'],
+      'comment_author_IP' => $_GET['ip'],
+      'comment_content' => 'registration',
+      'comment_author_url' => ''
+    );
+  } else {
+	  if ( empty( $comment ) ) {
+		  echo " No Comment Found for $comment_id";
+		  exit();
+	  }
+  }
 // print_r($comment);
 	$email   = urlencode( $comment['comment_author_email'] );
 	$uname   = urlencode( $comment['comment_author'] );
@@ -247,7 +257,7 @@ function sfs_handle_ajax_sub( $data ) {
 	} else if ( stripos( $ret, 'recent duplicate entry' ) !== false ) {
 		echo ' Recent Duplicate Entry ';
 	} else {
-		echo ' Returning from AJAX';
+		echo ' Returning from AJAX: ' . $hget . ' - ' . $ret;
 	}
 	exit();
 }

--- a/js/sfs_handle_ajax.js
+++ b/js/sfs_handle_ajax.js
@@ -32,13 +32,16 @@ function sfs_ajax_return_process(response) {
     return false;
 }
 
-function sfs_ajax_report_spam(t, id, blog, url) {
+function sfs_ajax_report_spam(t, id, blog, url, email, ip, user) {
     sfs_ajax_who = t;
     var data = {
         action: 'sfs_sub',
         blog_id: blog,
         comment_id: id,
-        ajax_url: url
+        ajax_url: url,
+        email: email,
+        ip: ip,
+        user: user
     }
     jQuery.get(ajaxurl, data, sfs_ajax_return_spam);
 }

--- a/settings/ss_reports.php
+++ b/settings/ss_reports.php
@@ -174,7 +174,7 @@ $now      = date( 'Y/m/d H:i:s', time() + ( get_option( 'gmt_offset' ) * 3600 ) 
 <td>$dt</td>
 <td>$em</td>
 <td>$ip $who $stopper $honeysearch $botsearch";
-				if ( stripos( $reason, 'passed' ) !== false && ( $id == '/' || strpos( $id, 'login' ) !== false ) && ! in_array( $ip, $blist ) && ! in_array( $ip, $wlist ) ) {
+				if ( stripos( $reason, 'passed' ) !== false && ( $id == '/' || strpos( $id, 'login' ) !== false || strpos( $id, 'register' ) !== false ) ) && ! in_array( $ip, $blist ) && ! in_array( $ip, $wlist ) ) {
 					$ajaxurl = admin_url( 'admin-ajax.php' );
 					echo "<a href=\"\" onclick=\"sfs_ajax_process( '$ip','log','add_black','$ajaxurl' );return false;\" title=\"Add to Deny List\" alt=\"Add to Deny List\" ><img src=\"$tdown\" height=\"16px\" /></a>";
 					$options = get_option( 'ss_stop_sp_reg_options' );

--- a/settings/ss_reports.php
+++ b/settings/ss_reports.php
@@ -174,8 +174,19 @@ $now      = date( 'Y/m/d H:i:s', time() + ( get_option( 'gmt_offset' ) * 3600 ) 
 <td>$dt</td>
 <td>$em</td>
 <td>$ip $who $stopper $honeysearch $botsearch";
-				if ( strpos( $reason, 'passed' ) !== false && ( $id == '/' || strpos( $id, 'login' ) !== false ) && ! in_array( $ip, $blist ) && ! in_array( $ip, $wlist ) ) {
-					echo "<a href=\"\" onclick=\"return addblack('$ip');\" title=\"Add to Deny List\" alt=\"Add to Deny List\" ><img src=\"$tdown\" height=\"16px\" /></a>";
+				if ( stripos( $reason, 'passed' ) !== false && ( $id == '/' || strpos( $id, 'login' ) !== false ) && ! in_array( $ip, $blist ) && ! in_array( $ip, $wlist ) ) {
+					$ajaxurl = admin_url( 'admin-ajax.php' );
+					echo "<a href=\"\" onclick=\"sfs_ajax_process( '$ip','log','add_black','$ajaxurl' );return false;\" title=\"Add to Deny List\" alt=\"Add to Deny List\" ><img src=\"$tdown\" height=\"16px\" /></a>";
+					$options = get_option( 'ss_stop_sp_reg_options' );
+					$apikey = $options['apikey'];
+					if ( !empty( $apikey ) ) {
+						$href="href=\"#\"";
+						$onclick="onclick=\"sfs_ajax_report_spam(this, 'registration', '$blog', '$ajaxurl', '$em', '$ip', '$au');return false;\"";
+					}
+					if ( !empty( $em ) ) {
+						echo "|";
+						echo "<a title=\"Report to Stop Forum Spam (SFS)\" $href $onclick class='delete:the-comment-list:comment-$id::delete=1 delete vim-d vim-destructive'>Report to SFS</a>";
+					}
 				}
 				echo "</td><td>$au</td>
 <td>$id</td>


### PR DESCRIPTION
Haven't looked at allow requests, but this is what I've been using locally for submitting from the log report page. (So it's a partial fix for #54, and maybe sufficient.)

The "Add to Deny List" link was already there but didn't work (there's no `addblack()` method) so this also fixes that.