### PR TITLE
bug with save opt

### DIFF
--- a/settings/ss_options.php
+++ b/settings/ss_options.php
@@ -35,7 +35,8 @@ if ( ! empty( $nonce ) && wp_verify_nonce( $nonce, 'ss_stopspam_update' ) ) {
 		'chkhosting',
 		'chkakismet',
 		'filterregistrations',
-		'chkform'
+		'chkform',
+		'chkubiquity',
 	);
 	foreach ( $optionlist as $check ) {
 		$v = 'N';


### PR DESCRIPTION
the variable 'chkubiquity' is  missed (_skipped_)
and the option '**Check Against List of Ubiquity-Nobis and Other Spam Server IPs**' is not saved if changed.